### PR TITLE
added missing "redhat-rpm-config" package

### DIFF
--- a/user/pages/02.development/01.getting.started/docs.md
+++ b/user/pages/02.development/01.getting.started/docs.md
@@ -65,6 +65,7 @@ The following packages are required for setting up the development environment,
  - `s3cmd`
  - `portaudio`
  - `portaudio-devel`
+ - `redhat-rpm-config`
  - `mpg123` (Available in RPMFusion)
 
 After installing the necessary packages, make sure to run the `dev_setup.sh` script that is provided in the `mycroft-core` folder.

--- a/user/pages/02.development/01.getting.started/docs.md
+++ b/user/pages/02.development/01.getting.started/docs.md
@@ -66,6 +66,7 @@ The following packages are required for setting up the development environment,
  - `portaudio`
  - `portaudio-devel`
  - `redhat-rpm-config`
+ - `bzip2`
  - `mpg123` (Available in RPMFusion)
 
 After installing the necessary packages, make sure to run the `dev_setup.sh` script that is provided in the `mycroft-core` folder.


### PR DESCRIPTION
For Fedora 24 (or at least for FedBerry 24) the redhat-rpm-config package is missing