### PR TITLE
Fix/skill framework documentation

### DIFF
--- a/07.skill.creation/02.vocabulary/docs.md
+++ b/07.skill.creation/02.vocabulary/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 ---
 
 
-The Adapt Intent parser has the ability to handle multiple vocabularly files. It also can parse sentences to find the key words. This means that vocabulary files need only focus on keywords, not specific uterances. 
+The Adapt Intent parser has the ability to handle multiple vocabulary files. It also can parse sentences to find the key words. This means that vocabulary files need only focus on keywords, not specific uterances. 
 
 
 For a good example of this, look at the Alarm Skill on Github:

--- a/07.skill.creation/02.vocabulary/docs.md
+++ b/07.skill.creation/02.vocabulary/docs.md
@@ -6,7 +6,7 @@ taxonomy:
 ---
 
 
-The Adapt Intent parser has the ability to handle multiple vocabularly files. It also can parse sentances to find the key words. This means that vocabulary files need only focus on keywords, not specific uterances. 
+The Adapt Intent parser has the ability to handle multiple vocabularly files. It also can parse sentences to find the key words. This means that vocabulary files need only focus on keywords, not specific uterances. 
 
 
 For a good example of this, look at the Alarm Skill on Github:

--- a/07.skill.creation/03.skills-framework/docs.md
+++ b/07.skill.creation/03.skills-framework/docs.md
@@ -1,9 +1,24 @@
 ---
-title: Mycroft Skills Framework
+title: Mycroft Skills Framework (Deprecated)
 taxonomy:
     category:
         - docs
 ---
+
+#### Mycroft Skills Framework and SDK is currently deprecated. You can still use the skills container for debugging either on the pi units (Mark 1 and picroft), or desktop. 
+
+For the pi units
+```
+mycroft-skill-container /path/to/skill
+```
+
+For the desktop
+```
+./start.sh skill_container /path/to/skill
+```
+
+-----
+
 The Mycroft Skills Framework is intended to allow you to develop skills by attaching your local developer code to a running Mycroft device (or MessageBus Service). By default, it will assume that you have a messagebus service running locally on port 8000, and you would drive your skill with a cli or speech client attached to the same message bus.
 
 This doc assumes you're working in an isolated virtualenv for your skill. You can also choose to install the sdk into your global python install with sudo.

--- a/07.skill.creation/04.skills-sdk/docs.md
+++ b/07.skill.creation/04.skills-sdk/docs.md
@@ -1,9 +1,23 @@
 ---
-title: Skills SDK
+title: Skills SDK (Deprecated)
 taxonomy:
     category:
         - docs
 ---
+
+#### Mycroft Skills Framework and SDK is currently deprecated. You can still use the skills container for debugging either on the pi units (Mark 1 and picroft), or desktop. 
+
+For the pi units
+```
+mycroft-skill-container /path/to/skill
+```
+
+For the desktop
+```
+./start.sh skill_container /path/to/skill
+```
+
+-----
 
 ## What Makes a Skill
 A skill is a class that extends the [MycroftSkill](https://github.com/MycroftAI/mycroft-core/blob/master/mycroft/skills/core.py#L98) class. It is instantiated by the skills container via a [create_skill](https://github.com/MycroftAI/skill-spelling/blob/master/__init__.py#L57) method on the skill module. See Mycroft's [spelling skill](https://github.com/MycroftAI/skill-spelling) for a simple example.


### PR DESCRIPTION
Deprecated the skills framework and SDK (currently doesn't work and confusing users).

Added notes on how to use the skill container without the skills sdk.